### PR TITLE
購入ボタンの表示

### DIFF
--- a/app/views/purchases/edit.html.haml
+++ b/app/views/purchases/edit.html.haml
@@ -61,3 +61,5 @@
           = link_to image_tag ( "//www-mercari-jp.akamaized.net/assets/img/common/common/google-play.svg?35314277")
 
 .purchases_Footer
+
+


### PR DESCRIPTION
○WHAT
商品が既に購入された物については購入ボタンが表示されないようにし、重複購入を防ぐように致しました。

○WHY
スプリントレビュー時にメンターより提示された追加項目に該当していたため。
本件は、（05   .一度購入された商品は「購入画面へ進む」ボタンを押せなくなっている）に該当致します。

